### PR TITLE
Fixed the planning parameter

### DIFF
--- a/t_frog_navigation/param/dwa_local_planner_params.yaml
+++ b/t_frog_navigation/param/dwa_local_planner_params.yaml
@@ -15,7 +15,7 @@ DWAPlannerROS:
   #   do not set min_trans_vel to 0.0 otherwise dwa will always think translational velocities
   #   are non-negligible and small in place rotational velocities will be created.
 
-  max_rot_vel: 1.0  # choose slightly less than the base's capability
+  max_rot_vel: 0.8  # choose slightly less than the base's capability
   min_rot_vel: 0.01  # this is the min angular velocity when there is negligible translational velocity
   rot_stopped_vel: 0.01
   


### PR DESCRIPTION
robot_controllerで設定した移動速度の上限値を超えるパラメータがNavigationに設定されていたため修正しました。
