### PR TITLE
Fix the navigation parameters

### DIFF
--- a/icart_mini_navigation/param/base_local_planner_params.yaml
+++ b/icart_mini_navigation/param/base_local_planner_params.yaml
@@ -1,12 +1,12 @@
 TrajectoryPlannerROS:
   holonomic_robot: false
-  max_vel_x: 0.7
-  min_vel_x: -0.7
+  max_vel_x: 0.55
+  min_vel_x: -0.55
   max_vel_y: 0.0
   min_vel_y: 0.0
   acc_lim_y: 0.0
   
-  acc_lim_x: 2.5
-  acc_lim_theta: 0.8
+  #acc_lim_x: 2.5
+  #acc_lim_theta: 0.8
 
   meter_scoring: true

--- a/icart_mini_navigation/param/move_base_params.yaml
+++ b/icart_mini_navigation/param/move_base_params.yaml
@@ -4,7 +4,7 @@
 #
 shutdown_costmaps: false
 
-controller_frequency: 4.0
+controller_frequency: 5.0
 controller_patience: 3.0
 
 planner_frequency: 1.0


### PR DESCRIPTION
自律走行時に0.7m/sで走行させることはypspurの速度制限を厳しくしたので出来なくなりました。
そこで、0.7m/sから0.55m/sに変更しました。
また、ロボットの直進性を高め経路を外れにくくするためにも制御周期を5Hzに引き上げた。
