### PR TITLE
hokuyo3d_joint change pitch level to 0.192

### DIFF
--- a/icart_mini_description/urdf/icart_mini_with_hokuyo3d.xacro
+++ b/icart_mini_description/urdf/icart_mini_with_hokuyo3d.xacro
@@ -184,7 +184,7 @@
   
   <joint name="hokuyo3d_joint" type="fixed">
     <axis xyz="0 1 0"/>
-    <origin xyz="0.27 0 0.35" rpy="0 0.034 0"/>
+    <origin xyz="0.27 0 0.35" rpy="0 0.192 0"/>
     <parent link="base_link"/>
     <child link="hokuyo3d_link"/>
   </joint>


### PR DESCRIPTION
実機では3DURGがピッチ方向に約11度(0.192 rad)ほど傾きをつけて設置しているため
icart_mini_description/urdf/icart_mini_with_hokuyo3d.xacro
のhokuyo3d_jointの
origin xyz="0.27 0 0.35" rpy="0 0.034 0"
部分を
origin xyz="0.27 0 0.35" rpy="0 0.192 0"
に変更
