### PR TITLE
waypoint通過判定用の範囲を半径0.5mから半径0.8mに変更

### DIFF
--- a/waypoints_navigation/src/waypoints_nav.cpp
+++ b/waypoints_navigation/src/waypoints_nav.cpp
@@ -214,7 +214,7 @@ public:
         return move_base_action_.getState() == actionlib::SimpleClientGoalState::SUCCEEDED;
     }
 
-    bool onNavigationPoint(const geometry_msgs::Point &dest, double dist_err = 0.5){
+    bool onNavigationPoint(const geometry_msgs::Point &dest, double dist_err = 0.8){
         tf::StampedTransform robot_gl = getRobotPosGL();
 
         const double wx = dest.x;


### PR DESCRIPTION
- waypoint通過時に姿勢を左右に降るような動作があったため，waypoint通過時の許容範囲(waypoints_nav.pp内，関数onNavigationPointのdist_err)を0.5(m)→0.8(m)に変更．
- 屋外における実機でのスムーズな動作も確認．
