### PR TITLE
Change default imu package and node name

### DIFF
--- a/icart_mini.install
+++ b/icart_mini.install
@@ -3,8 +3,8 @@
     local-name: icart_mini
     version: indigo-devel
 - git:
-    uri: https://github.com/open-rdc/adis_imu_drivers
-    local-name: adis_imu_drivers
+    uri: https://github.com/open-rdc/cit_adis_imu/
+    local-name: cit_adis_imu
     version: indigo-devel
 - git:
     uri: https://github.com/ros-controls/ros_controllers

--- a/icart_mini_driver/launch/icart_mini_drive.launch
+++ b/icart_mini_driver/launch/icart_mini_drive.launch
@@ -16,7 +16,7 @@
     <param name="port" value="$(arg scan_dev)"/>
   </node>
 
-  <node pkg="imu" type="imu" name="imu">
+  <node pkg="cit_adis_imu" type="imu_node" name="imu">
     <param name="port_name" value="$(arg imu_dev)"/>
     <param name="z_axis_dir" value="-1"/>
   </node>


### PR DESCRIPTION
デフォルトで導入しているIMUのパッケージ名及びノード名の変更( https://github.com/open-rdc/cit_adis_imu/issues/14 )をサポートした
