### PR TITLE
hokuyo3d.urdf.xacroの修正

### DIFF
--- a/icart_mini_description/urdf/sensors/hokuyo3d.urdf.xacro
+++ b/icart_mini_description/urdf/sensors/hokuyo3d.urdf.xacro
@@ -8,10 +8,10 @@
 	      <axis xyz="1 0 0"/>
 	      <insert_block name="origin"/>
 	      <parent link="${parent}"/>
-	      <child link="${name}_link"/>
+	      <child link="${name}"/>
 	  </joint>
 	
-	  <link name="${name}_link">
+	  <link name="${name}">
 	      <inertial>
 	        <mass value="0.001"/>
 	        <origin rpy="0 0 0" xyz="0 0 0"/>
@@ -31,7 +31,7 @@
 	      </collision>
 	  </link>
 	  
-      <gazebo reference="${name}_link">
+      <gazebo reference="${name}">
         <sensor name="velodyne" type="ray">
         <always_on>true</always_on>
         <visualize>false</visualize>
@@ -61,7 +61,7 @@
           <gaussianNoise>0.02</gaussianNoise>
           <updateRate>20</updateRate>
           <topicName>/${name}/hokuyo_cloud</topicName>
-          <frameName>${name}_link</frameName>
+          <frameName>${name}</frameName>
         </plugin>
       </sensor>
     </gazebo>


### PR DESCRIPTION
hokuyo3dノード側のframe_idがhokuyo3dのため，実機ではhokuyo3dのリンク名を{name}_linkから{name}に変更する必要があった

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/open-rdc/icart_mini/108)

<!-- Reviewable:end -->
