### PR TITLE
fix cmd_vel_timeout

### DIFF
--- a/icart_mini_control/config/icart_mini_control.yaml
+++ b/icart_mini_control/config/icart_mini_control.yaml
@@ -19,7 +19,7 @@ icart_mini:
     wheel_radius_multiplier    : 1.0 # default: 1.0
 
     # Velocity commands timeout [s], default 0.5
-    cmd_vel_timeout: 20
+    cmd_vel_timeout: 1.0
 
     # Base frame_id
     base_frame_id: base_link


### PR DESCRIPTION
速度指令のタイムアウトが20[s]になっていたため1.0[s]に修正．
