### PR TITLE
ターボモードの速度変更

### DIFF
--- a/icart_mini_driver/config/elecom_joy.yaml
+++ b/icart_mini_driver/config/elecom_joy.yaml
@@ -1,6 +1,6 @@
 axis_linear: 1
 scale_linear: 0.6
-scale_linear_turbo: 0.8
+scale_linear_turbo: 1.0
 
 axis_angular: 0
 scale_angular: 0.9


### PR DESCRIPTION
今までの速度では横断歩道が渡りきれなかったので、ターボモードの速度をあげた