### PR TITLE
gazeboで動かないバグの修正

### DIFF
--- a/icart_mini_driver/launch/icart_mini_drive.launch
+++ b/icart_mini_driver/launch/icart_mini_drive.launch
@@ -17,6 +17,8 @@
     <param name="ip_address"  value="$(arg urg_ip)" if="$(arg use_eth_urg)"/>
     <param name="serial_port" value="$(arg scan_dev)" unless="$(arg use_eth_urg)"/>
     <param name="publish_multiecho" value="false"/>
+	<param name="angle_min" value="-1.57"/>
+	<param name="angle_max" value="1.57"/>
   </node>
 
   <node name="icart_mini_driver_node" pkg="icart_mini_driver" output="screen" type="icart_mini_driver_node"/>

--- a/icart_mini_gazebo/src/icart_mini_hw_sim.cpp
+++ b/icart_mini_gazebo/src/icart_mini_hw_sim.cpp
@@ -117,20 +117,22 @@ namespace icart_mini_gazebo
 
         void writeSim(ros::Time time, ros::Duration period){
             for(int i=0; i < 2; i++){
-                joint_[i]->SetParam("vel", 0, cmd_[i]);
-                joint_[i]->SetParam("max_velocity", 0, max_drive_joint_torque_);
+				joint_[i]->SetVelocity(0, cmd_[i]);
+				joint_[i]->SetVelocityLimit(0, max_drive_joint_torque_);
             }
             
+            
             /*
-            if(safety_interface_.get_state() == safety_interface::safety_state::OK){
+			if(safety_interface_.get_state() == safety_interface::safety_state::OK){
                 for(int i=0; i < 2; i++){
-                    joint_[i]->SetVelocity(0, cmd_[i]);
-                    joint_[i]->SetMaxForce(0, max_drive_joint_torque_);
+                    //joint_[i]->SetVelocity(0, cmd_[i]);
+                    //joint_[i]->SetMaxForce(0, max_drive_joint_torque_);
                 }
             }else{
                 for(int i=0; i < 2; i++) joint_[i]->SetVelocity(0, 0);
             }
-            */
+			*/
+            
         }
     };
 


### PR DESCRIPTION
gazebo上で速度司令を送っても機体が動かないバグの修正を行った
gazebo上で挙動確認済み

また、水平urgのスキャンレンジが-135°〜135°と広かったので、-90°~90°に変更した