### PR TITLE
refine build option

### DIFF
--- a/icart_mini.install
+++ b/icart_mini.install
@@ -3,10 +3,6 @@
     local-name: icart_mini
     version: melodic-devel
 - git:
-    uri: https://github.com/open-rdc/cit_adis_imu/
-    local-name: cit_adis_imu
-    version: indigo-devel
-- git:
-    uri: https://github.com/DaikiMaekawa/ypspur/
+    uri: https://github.com/open-rdc/ypspur/
     local-name: ypspur
-    version: indigo-devel
+    version: melodic-devel

--- a/icart_mini_driver/CMakeLists.txt
+++ b/icart_mini_driver/CMakeLists.txt
@@ -7,8 +7,6 @@ find_package(catkin REQUIRED COMPONENTS
     controller_manager
 )
 
-find_package(ypspur 1.17.0 REQUIRED)
-
 catkin_package(
 #  INCLUDE_DIRS include
 #  LIBRARIES icart_mini_driver
@@ -16,16 +14,20 @@ catkin_package(
 #  DEPENDS system_lib
 )
 
+#include_directories(/usr/share/include)
+
 include_directories(
     ${catkin_INCLUDE_DIRS}
-    ${ypspur_INCLUDE_DIRS}
+    ${YPSPUR_INCLUDE_DIRS}
 )
+
+find_package(ypspur)
 
 add_executable(icart_mini_driver_node src/icart_mini_driver_node.cpp)
 
 target_link_libraries(icart_mini_driver_node
     ${catkin_LIBRARIES}
-    ypspur
+    ${YPSPUR_LIBRARIES}
 )
 
 install(FILES


### PR DESCRIPTION
ビルド時にypspur.hが見つからないとエラーが出力されることに対しての対処

@taishiyamamoto レビューお願いします．